### PR TITLE
Documentation additions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-gem 'github-pages'
+gem 'github-pages', '15'
 
 gem 'jekyll-haml'
 gem 'jekyll-sass'

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-pygments: true
+highlighter: pygments
 exclude: [Gemfile, Gemfile.lock, Rakefile, tags]
 sass:
   syntax: scss        # scss|sass

--- a/_includes/pages/audio.md
+++ b/_includes/pages/audio.md
@@ -9,3 +9,40 @@ sound_manager.play_music :overworld
 # sounds
 sound_manager.play_sound :death
 {% endhighlight %}
+
+Music will continue playing when scenes transition.  You could explicitly stop / start / change the music by calling `.stop_music :overworld`.  For example, let's say you wanted to have music in the main gameplay stage but then play pause menu music when the player presses ESC.
+
+{% highlight ruby %}
+define_stage :demo do
+  curtain_up do
+    sound_manager.play_music :game_music
+    # ...
+    # register key events or something that changes stages
+  end
+end
+
+define_stage :pause_menu do
+  curtain_up do
+    sound_manager.stop_music :game_music
+    sound_manager.play_music :pause_music
+    # ...
+  end
+end
+{% endhighlight %}
+
+Sounds are placed in `data/sounds`.  Audio is handled by gosu and gosu supports ogg/wav/mp3 file formats as well as others.  Filenames are converted to symbols without the file extension.  For example:
+
+{% highlight text %}
+data/music/ambient.mp3
+{% endhighlight %}
+
+The file `ambient.mp3` would be played with `sound_manager.play_music :ambient`.  Files are accessed in alphabetical order.  If you have two files that have the same name, gamebox will use the first one.
+
+{% highlight text %}
+data/music/ambient.mp3
+data/music/ambient.ogg
+{% endhighlight %}
+
+In this case with two files, `sound_manager.play_music :ambient` plays `ambient.mp3` only (because "m" in mp3 comes before "o" in ogg).  So name your files uniquely without relying on the file extension.  This is true of all gamebox assets.
+
+Music files can only be played one at a time.  They won't mix.  If music is playing with the same name, playing it again won't restart it.  If you want to restart music, you can just stop/start it explicitly.

--- a/_includes/pages/input.md
+++ b/_includes/pages/input.md
@@ -21,3 +21,28 @@ if actor.input.walk_left?
   # walk left
 end
 {% endhighlight %}
+
+The stage has access to the InputManager via the input_manager object that is in scope.  For example, if we explicitly wanted to make the ESC key fire the pause menu stage, we could do this:
+
+{% highlight ruby %}
+define_stage :flying do
+
+  curtain_up do
+    # ...
+    input_manager.reg :down, K_ESCAPE do
+      fire :change_stage, :pause_menu
+      # be sure to explicitly list your stages in config/environment.rb
+      # so gamebox knows what :pause_menu is
+    end
+    # ...
+  end
+end
+{% endhighlight %}
+
+The listing of key input constants is in `gamebox/lib/gamebox/constants.rb` but here are a few to give you an idea:
+
+{% highlight text %}
+K_RETURN  K_A  K_B  K_C  K_ESCAPE  K_SPACE  K_RSHIFT  K_LSHIFT
+{% endhighlight %}
+
+In order to use these shorthand K_ constants, `require 'gamebox/constants'` in `config/environment.rb`.


### PR DESCRIPTION
Sorry for the mixed PR.  The `Gemfile` version lock is what made jekyll render haml correctly.  Current version is 31 so there's some breaking change in there somewhere.  Pygments option has changed 6f6b1eab7ef1bf01f27fd962666d46e11ff74619 (deprecation warning but that also might be a version change -- you might want to review/think about this commit).

The other two doc: commits are document additions.  I will continue if you think the voice/style is ok.
